### PR TITLE
Cycle minimiser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ out_dir = "custom"
 members = [
     "libafl_verdi",
     "libafl_verilator",
+    "hw_utils"
 ]
 exclude = [
     "fuzzers",

--- a/fuzzers/opentitan-fuzzer-vcs/Cargo.toml
+++ b/fuzzers/opentitan-fuzzer-vcs/Cargo.toml
@@ -15,8 +15,8 @@ std = []
 
 [dependencies]
 clap = { version = "3.2", features = ["default"] }
-libafl = { version = "0.8.2" }
-libverdi = { path = "../../libverdi" }
+libafl = { version = "0.9.0" }
+libafl_verdi = { path = "../../libafl_verdi" }
 nix = "0.24"
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib

--- a/fuzzers/opentitan-fuzzer-vcs/Cargo.toml
+++ b/fuzzers/opentitan-fuzzer-vcs/Cargo.toml
@@ -25,3 +25,6 @@ ahash = { version = "0.7", default-features=false, features=["compile-time-rng"]
 intervaltree = { version = "0.2.7", default-features = false, features = ["serde"] }
 libc = "0.2"
 fs_extra = "1.2.0"
+tempdir = "0.3.7"
+
+

--- a/fuzzers/opentitan-fuzzer-vcs/init.sh
+++ b/fuzzers/opentitan-fuzzer-vcs/init.sh
@@ -14,7 +14,7 @@ fusesoc library add opentitan https://github.com/lowRISC/opentitan.git
 cp ./Dockerfile ./fusesoc_libraries/opentitan/util/container/Dockerfile
 
 if [[ "$(docker images -q opentitan 2> /dev/null)" == "" ]]; then
-  cd ./fusesoc_libraries/opentitan  
+  cd ./fusesoc_libraries/opentitan
   docker build --network=host --build-arg proxy=$https_proxy -t opentitan -f ./util/container/Dockerfile .
   cd ../..
 fi

--- a/fuzzers/opentitan-fuzzer-vcs/src/vcs_executor.rs
+++ b/fuzzers/opentitan-fuzzer-vcs/src/vcs_executor.rs
@@ -19,7 +19,6 @@ use libafl::{
 use std::path::Path;
 use std::io::prelude::*;
 use std::fs::File;
-use std::io::{ self, BufRead, BufReader };
 //
 // Create the executor for an in-process function with just one observer
 #[derive(Debug)]
@@ -67,13 +66,9 @@ impl CommandConfigurator for VCSExecutor
             .stderr(Stdio::piped());
 
         let child = command.spawn().expect("failed to start process");
-        // println!("Execution done");
 
-        let output = command.output().expect("failed to start process");
+        // let output = command.output().expect("failed to start process");
         // println!("status: {}", String::from_utf8_lossy(&output.stdout));
-
-        // let ten_millis = time::Duration::from_millis(30000);
-        // thread::sleep(ten_millis);
 
         Ok(child)
     }

--- a/fuzzers/opentitan-fuzzer-vcs/src/vcs_executor.rs
+++ b/fuzzers/opentitan-fuzzer-vcs/src/vcs_executor.rs
@@ -26,19 +26,16 @@ pub struct VCSExecutor
 {
     pub executable: String,
     pub args: String,
-    pub outdir: String
+    pub workdir: String
 }
 
 impl CommandConfigurator for VCSExecutor
 { 
     fn spawn_child<I: Input + HasTargetBytes>(&mut self, input: &I) -> Result<Child, Error> {
         
-        let mut input_filename = self.outdir.clone();
-        input_filename.push_str("/fuzz_input.hex");
-
         let do_steps = || -> Result<(), Error> {
 
-            let mut file = File::create(input_filename)?;
+            let mut file = File::create("testcase")?;
             let hex_input = input.target_bytes();
             let hex_input2 = hex_input.as_slice();
             for i in 0..hex_input2.len()-1 {
@@ -52,9 +49,6 @@ impl CommandConfigurator for VCSExecutor
             println!("VCSExecutor failed to create new input file, please check output argument");
         }
 
-        let dir = Path::new(self.executable.as_str()).parent().unwrap();
-        std::env::set_current_dir(dir).expect("Unable to change into {dir}");
-
         let mut command = pcmd::new(self.executable.as_str());
 
         let command = command
@@ -67,8 +61,9 @@ impl CommandConfigurator for VCSExecutor
 
         let child = command.spawn().expect("failed to start process");
 
-        // let output = command.output().expect("failed to start process");
-        // println!("status: {}", String::from_utf8_lossy(&output.stdout));
+        let output = command.output().expect("failed to start process");
+        println!("status: {}", String::from_utf8_lossy(&output.stdout));
+        // println!("status: {}", String::from_utf8_lossy(&output.stderr));
 
         Ok(child)
     }

--- a/fuzzers/secworks-vcs/Cargo.toml
+++ b/fuzzers/secworks-vcs/Cargo.toml
@@ -21,7 +21,7 @@ out_dir = "runner"
 [dependencies]
 clap = { version = "3.2", features = ["default"] }
 libafl = { version = "0.9.0" }
-libverdi = { path = "../../libverdi" }
+libafl_verdi = { path = "../../libafl_verdi" }
 nix = "0.24"
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib

--- a/fuzzers/secworks-vcs/init.sh
+++ b/fuzzers/secworks-vcs/init.sh
@@ -4,38 +4,37 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cargo clean
+#cargo clean
 
-rm -rf build
-rm -rf fusesoc*
-rm -rf template
-rm -rf output
-rm -rf backup_*
+#rm -rf build
+#rm -rf fusesoc*
+#rm -rf template
+#rm -rf output
+#rm -rf backup_*
 
-fusesoc library add sha256 https://github.com/secworks/sha256
+#fusesoc library add sha256 https://github.com/secworks/sha256
 
-cp ./tb_fuzz.sv ./fusesoc_libraries/sha256/src/tb/
+#cp ./tb_fuzz.sv ./fusesoc_libraries/sha256/src/tb/
 
-echo "  tb_fuzz:" >> fusesoc_libraries/sha256/sha256.core
-echo "    <<: *tb" >> fusesoc_libraries/sha256/sha256.core
-echo "    toplevel : tb_fuzz" >> fusesoc_libraries/sha256/sha256.core
-sed -i '/tb_sha256.v/a \ \ \ \ \ \ - src\/tb\/tb_fuzz.sv' fusesoc_libraries/sha256/sha256.core
+#echo "  tb_fuzz:" >> fusesoc_libraries/sha256/sha256.core
+#echo "    <<: *tb" >> fusesoc_libraries/sha256/sha256.core
+#echo "    toplevel : tb_fuzz" >> fusesoc_libraries/sha256/sha256.core
+#sed -i '/tb_sha256.v/a \ \ \ \ \ \ - src\/tb\/tb_fuzz.sv' fusesoc_libraries/sha256/sha256.core
 
-fusesoc run --build --target=tb_fuzz --tool=vcs secworks:crypto:sha256 --vcs_options '-LDFLAGS -Wl,--no-as-needed -cm line+fsm+cond+tgl+branch -cm_dir Coverage.vdb -full64 -sverilog'
+#fusesoc run --build --target=tb_fuzz --tool=vcs secworks:crypto:sha256 --vcs_options '-LDFLAGS -Wl,--no-as-needed -cm line+fsm+cond+tgl+branch -cm_dir Coverage.vdb -full64 -sverilog'
 
-cargo build
+#cargo build
 
-mkdir output
-cp -r build/secworks_crypto_sha256_0/tb_fuzz-vcs/* ./output
+#mkdir output
+#cp -r build/secworks_crypto_sha256_0/tb_fuzz-vcs/* ./output
 
-crg -dir ./output/Coverage.vdb -shared init
+#crg -dir ./output/Coverage.vdb -shared init
 
 export HW_HOME=$(pwd)
 
 mkdir $HW_HOME/seeds/
 
 ./target/debug/baby-rtl-fuzzer $HW_HOME/output/secworks_crypto_sha256_0 \
-	$HW_HOME/output/ \
 	$HW_HOME/seeds/ \
 	$HW_HOME/output/Coverage.vdb \
 	$HW_HOME/output/ "+TESTCASE=fuzz_input.hex -cm tgl"

--- a/fuzzers/secworks-vcs/src/main.rs
+++ b/fuzzers/secworks-vcs/src/main.rs
@@ -11,6 +11,11 @@ use std::{
 use clap::Arg;
 use clap::Command as clap_cmd;
 
+#[cfg(not(target_vendor = "apple"))]
+use libafl::bolts::shmem::StdShMemProvider;
+#[cfg(target_vendor = "apple")]
+use libafl::bolts::shmem::UnixShMemProvider;
+
 #[cfg(feature = "tui")]
 use libafl::monitors::tui::TuiMonitor;
 #[cfg(not(feature = "tui"))]
@@ -19,7 +24,9 @@ use libafl::{
     bolts::{
         current_nanos,
         rands::StdRand,
+        shmem::{ShMem, ShMemProvider},
         tuples::tuple_list,
+        AsMutSlice
     },
     events::SimpleEventManager,
     feedbacks::{CrashFeedback, TimeFeedback},
@@ -30,16 +37,96 @@ use libafl::{
     schedulers::QueueScheduler,
     stages::mutational::StdMutationalStage,
     state::StdState,
-    corpus::{OnDiskCorpus},
+    corpus::{InMemoryCorpus, OnDiskCorpus},
     inputs::bytes::BytesInput,
 };
-use libafl::executors::command::CommandConfigurator;
+use libafl::monitors::Monitor;
+use core::time::Duration;
+use libafl::prelude::format_duration_hms;
+use libafl::prelude::ClientStats;
+use libafl::prelude::current_time;
 
-use libverdi::verdi_feedback::VerdiFeedback as VerdiFeedback;
-use libverdi::verdi_observer::VerdiMapObserver as VerdiObserver;
-use libverdi::verdi_observer::VerdiCoverageMetric;
+use libafl::executors::command::CommandConfigurator;
+use libafl::prelude::MaxMapFeedback;
+
+use libafl_verdi::verdi_feedback::VerdiFeedback as VerdiFeedback;
+use libafl_verdi::verdi_observer::VerdiShMapObserver;
+use libafl_verdi::verdi_observer::VerdiCoverageMetric;
 
 mod vcs_executor;
+
+#[cfg(feature = "std")]
+/// Tracking monitor during fuzzing that just prints to `stdout`.
+#[derive(Debug, Clone, Default)]
+pub struct VCSMonitor {
+    start_time: Duration,
+    client_stats: Vec<ClientStats>,
+}
+
+#[cfg(feature = "std")]
+impl VCSMonitor {
+    /// Create a new [`VCSMonitor`]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "std")]
+impl Monitor for VCSMonitor {
+    /// the client monitor, mutable
+    fn client_stats_mut(&mut self) -> &mut Vec<ClientStats> {
+        &mut self.client_stats
+    }
+
+    /// the client monitor
+    fn client_stats(&self) -> &[ClientStats] {
+        &self.client_stats
+    }
+
+    /// Time this fuzzing run stated
+    fn start_time(&mut self) -> Duration {
+        self.start_time
+    }
+
+    fn display(&mut self, event_msg: String, sender_id: u32) {
+        println!(
+            "[{} #{}] run time: {}, clients: {}, corpus: {}, objectives: {}, executions: {}, exec/sec: {}",
+            event_msg,
+            sender_id,
+            format_duration_hms(&(current_time() - self.start_time)),
+            self.client_stats().len(),
+            self.corpus_size(),
+            self.objective_size(),
+            self.total_execs(),
+            self.execs_per_sec(),
+            // self.execs_per_sec_pretty(),
+        );
+
+        let mut id = 0;
+        for client in self.client_stats_mut() {
+            let coverage = client.get_user_stats("coverage");
+            match coverage {
+                Some(coverage) => println!("Client {} -> {} % coverage score.", id, coverage),
+                None          => println!("Client {} -> {} % coverage score.", id, 0),
+            }
+            id += 1;
+        }
+        println!();
+
+        // Only print perf monitor if the feature is enabled
+        #[cfg(feature = "introspection")]
+        {
+            // Print the client performance monitor.
+            println!(
+                "Client {:03}:\n{}",
+                sender_id, self.client_stats[sender_id as usize].introspection_monitor
+            );
+            // Separate the spacing just a bit
+            println!();
+        }
+    }
+}
 
 #[allow(clippy::similar_names)]
 pub fn main() {
@@ -98,14 +185,31 @@ pub fn main() {
         )
         .get_matches();
 
-    // const MAP_SIZE: usize = 65536;
-    // let mut shmem_provider = unix_shmem::MmapShMemProvider::new().unwrap();
-    // The coverage map shared between observer and executor
-    // The shared memory id is saved in __AFL_SHM_ID 
-    // let mut shmem = shmem_provider.new_shmem(MAP_SIZE).unwrap();
-    // shmem.write_to_env("__AFL_SHM_ID").unwrap();
-    // let shmem_id = shmem.id();
-    // let shmem_buf = shmem.as_mut_slice();
+    const MAP_SIZE: usize = 65536*4;
+
+    //Coverage map shared between observer and executor
+    #[cfg(target_vendor = "apple")]
+    let mut shmem_provider = UnixShMemProvider::new().unwrap();
+    #[cfg(not(target_vendor = "apple"))]
+    let mut shmem_provider = StdShMemProvider::new().unwrap();
+    let mut shmem = shmem_provider.new_shmem(MAP_SIZE).unwrap();
+    //let the forkserver know the shmid
+    shmem.write_to_env("__AFL_SHM_ID").unwrap();
+    let shmem_buf = shmem.as_mut_slice();
+    println!("shmem_buf at addr {:p}", shmem_buf.as_mut_ptr());
+    let shmem_ptr = shmem_buf.as_mut_ptr() as *mut u32;
+
+    let (mut feedback, verdi_observer) = 
+    {
+        let outdir = res.value_of("outdir").unwrap().to_string();
+        // let verdi_observer = VerdiShMapObserver::<u32, MAP_SIZE>::new("verdi_map", &outdir, *shmem_ptr, &VerdiCoverageMetric::Toggle);
+        let verdi_observer = VerdiShMapObserver::<u32, {MAP_SIZE/4}>::from_mut_ptr("verdi_map", &outdir, shmem_ptr, &VerdiCoverageMetric::Toggle);
+
+        let mut feedback = VerdiFeedback::<u32, {MAP_SIZE/4}>::new_with_observer("verdi_map", MAP_SIZE, &outdir);
+        // let mut feedback = MaxMapFeedback::new(&verdi_observer);
+
+        (feedback, verdi_observer)
+    };
 
     // Load user provided parameters
     let executable = res.value_of("executable").unwrap().to_string();
@@ -119,42 +223,33 @@ pub fn main() {
     // The vcs observer observes the coverage metrics exposed by vcs
     // The coverage is for now collected by another process since the lib is in c++
     // But would be interesting to get everything at one place in the future
-    let map_size: usize = 42000;
+    // let map_size: usize = 42000;
 
-    let outdir = res.value_of("outdir").unwrap().to_string();
-    let verdi_observer = VerdiObserver::new("verdi_map", &vdb, map_size, &VerdiCoverageMetric::toggle);
+    // let outdir = res.value_of("outdir").unwrap().to_string();
+    // let verdi_observer = VerdiObserver::new("verdi_map", &vdb, map_size, &VerdiCoverageMetric::toggle);
 
     // Create an observation channel to keep track of the execution time
     let time_observer = TimeObserver::new("time");
 
     // Feedback to rate the interestingness of an input
     // This one is composed by two Feedbacks in OR
-    let outdir = res.value_of("outdir").unwrap().to_string();
-    let mut feedback = feedback_or!(
-        VerdiFeedback::new_with_observer("verdi_map", map_size, &outdir),
-        TimeFeedback::with_observer(&time_observer)
-    );
+    // let outdir = res.value_of("outdir").unwrap().to_string();
+    // let mut feedback = feedback_or!(
+        // VerdiFeedback::new_with_observer("verdi_map", map_size, &outdir),
+        // TimeFeedback::with_observer(&time_observer)
+    // );
 
     // A feedback to choose if an input is a solution or not
     // We want to do the same crash deduplication that AFL does
-    let mut objective = feedback_and_fast!(
-        // When an assertion failed, we could trigger a POSIX signal value
-        // that mimics a crash.
-        CrashFeedback::new(),
-        // Take it only if trigger new coverage over crashes
-        // This will discard redondant findings
-        CrashFeedback::new()
-        // MaxMapFeedback::<_, _, _, u8>::new(&vcs_observer)
-    );
+    let mut objective = ();
 
     // If not restarting, create a State from scratch
-    let corpus_dir = PathBuf::from(res.value_of("corpus").unwrap().to_string());
     let mut state = StdState::new(
         // RNG
         StdRand::with_seed(current_nanos()),
         // Use on disk corpus, so that we keep trace of it
         // Performance impact is negligeable as the target is way slower
-        OnDiskCorpus::<BytesInput>::new(corpus_dir).unwrap(),
+        InMemoryCorpus::<BytesInput>::new(),
         // Corpus in which we store solutions (crashes in this example),
         // on disk so the user can get them after stopping the fuzzer
         OnDiskCorpus::new(&solution_dir).unwrap(),
@@ -167,7 +262,8 @@ pub fn main() {
     .unwrap();
 
     // The Monitor trait define how the fuzzer stats are displayed to the user
-    let mon = SimpleMonitor::new(|s| println!("{}", s));
+    // let mon = SimpleMonitor::new(|s| println!("{}", s));
+    let mon = VCSMonitor::new();
 
     // The event manager handle the various events generated during the fuzzing loop
     // such as the notification of the addition of a new item to the corpus

--- a/hw_utils/Cargo.toml
+++ b/hw_utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hw_utils"
+authors = ["Addison Crump <addison.crump@cispa.de>"]
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libafl = { version = "0.9.0" }
+num-traits = "0.2.15"
+serde = { version = "1.0", default-features = false, features = ["alloc"] } # serialization lib

--- a/hw_utils/src/lib.rs
+++ b/hw_utils/src/lib.rs
@@ -1,0 +1,322 @@
+use libafl::bolts::{AsIter, HasLen};
+use libafl::corpus::Testcase;
+use libafl::events::EventFirer;
+use libafl::executors::ExitKind;
+use libafl::feedbacks::{Feedback, MinMapFeedback};
+use libafl::inputs::UsesInput;
+use libafl::observers::Observer;
+use libafl::observers::{MapObserver, ObserversTuple};
+use libafl::prelude::{MaxMapFeedback, Named};
+use libafl::state::{HasClientPerfMonitor, HasNamedMetadata};
+use libafl::Error;
+use num_traits::Bounded;
+
+use serde::{Deserialize, Serialize};
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+/// Implemented by observers which detect the number of executed cycles.
+pub trait CyclesExecutedObserver {
+    /// The number of cycles in this execution.
+    fn cycles(&self) -> u64;
+}
+
+/// Map feedback which preprocesses the cycles into a map such that if a coverage point is
+/// non-initial in the provided coverage map, then it is mapped into the coverage map as the number
+/// of cycles for that execution. An execution is then "interesting" if it reduces the number of
+/// cycles from the best so far. This may be used in place of a typical coverage map.
+#[derive(Debug)]
+pub struct CyclesMapFeedback<F, CO, MO> {
+    inner: F,
+    cycles_initial: u64,
+    cycles_obs_name: String,
+    map_obs_name: String,
+    proxy_name: Option<String>,
+    phantom: PhantomData<(CO, MO)>,
+}
+
+impl<F, CO, MO> CyclesMapFeedback<F, CO, MO>
+where
+    CO: Named,
+    MO: Named,
+{
+    fn _new(
+        feedback: F,
+        cycles_initial: u64,
+        cycles_obs: &CO,
+        map_obs: &MO,
+        proxy_name: String,
+    ) -> Self {
+        Self {
+            inner: feedback,
+            cycles_initial,
+            cycles_obs_name: cycles_obs.name().to_string(),
+            map_obs_name: map_obs.name().to_string(),
+            proxy_name: Some(proxy_name),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<CO, MO, S, T> CyclesMapFeedback<MinMapFeedback<CyclesMapProxy<MO>, S, u64>, CO, MO>
+where
+    CO: CyclesExecutedObserver + Named,
+    MO: MapObserver<Entry = T> + Observer<S> + for<'a> AsIter<'a, Item = T>,
+    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor + Debug,
+    T: Bounded + PartialEq + Default + Copy + Debug + 'static,
+{
+    pub fn minimising(
+        cycles_obs: &CO,
+        map_obs: &MO,
+        track_indexes: bool,
+        track_novelties: bool,
+    ) -> Self {
+        let temp = CyclesMapProxy::new(
+            format!("cycles_{}", cycles_obs.name()),
+            cycles_obs,
+            map_obs,
+            u64::MAX,
+        );
+        let feedback = MinMapFeedback::new_tracking(&temp, track_indexes, track_novelties);
+        Self::_new(feedback, u64::MAX, cycles_obs, map_obs, temp.take_name())
+    }
+}
+
+impl<CO, MO, S, T> CyclesMapFeedback<MaxMapFeedback<CyclesMapProxy<MO>, S, u64>, CO, MO>
+where
+    CO: CyclesExecutedObserver + Named,
+    MO: MapObserver<Entry = T> + Observer<S> + for<'a> AsIter<'a, Item = T>,
+    S: UsesInput + HasNamedMetadata + HasClientPerfMonitor + Debug,
+    T: Bounded + PartialEq + Default + Copy + Debug + 'static,
+{
+    pub fn minimising(
+        cycles_obs: &CO,
+        map_obs: &MO,
+        track_indexes: bool,
+        track_novelties: bool,
+    ) -> Self {
+        let temp = CyclesMapProxy::new(
+            format!("cycles_{}", cycles_obs.name()),
+            cycles_obs,
+            map_obs,
+            0,
+        );
+        let feedback = MaxMapFeedback::new_tracking(&temp, track_indexes, track_novelties);
+        Self::_new(feedback, 0, cycles_obs, map_obs, temp.take_name())
+    }
+}
+
+impl<F, CO, MO> Named for CyclesMapFeedback<F, CO, MO>
+where
+    F: Named,
+{
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+}
+
+fn undeserializeable<T>() -> T {
+    panic!("Cannot deserialize type.")
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct CyclesMapProxy<MO> {
+    name: String,
+    #[serde(skip, default = "undeserializeable")]
+    map: *const MO,
+    initial: u64,
+    cycles: u64,
+}
+
+impl<MO> CyclesMapProxy<MO> {
+    fn new<CO: CyclesExecutedObserver>(
+        name: String,
+        cycles_obs: &CO,
+        map_obs: &MO,
+        initial: u64,
+    ) -> Self {
+        Self {
+            name,
+            map: map_obs,
+            initial,
+            cycles: cycles_obs.cycles(),
+        }
+    }
+
+    fn take_name(self) -> String {
+        self.name
+    }
+}
+
+impl<MO> Named for CyclesMapProxy<MO> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl<S, MO> Observer<S> for CyclesMapProxy<MO>
+where
+    MO: Debug,
+    S: UsesInput,
+{
+}
+
+impl<MO> HasLen for CyclesMapProxy<MO>
+where
+    MO: HasLen,
+{
+    fn len(&self) -> usize {
+        unsafe { self.map.as_ref().unwrap_unchecked().len() }
+    }
+}
+
+struct CycleIndexIter<'a, MO, T>
+where
+    MO: MapObserver<Entry = T> + for<'b> AsIter<'b, Item = T>,
+    T: Bounded + PartialEq + Default + Copy + Debug + 'static,
+{
+    map_initial: T,
+    into_iter: <MO as AsIter<'a>>::IntoIter,
+    initial: &'a u64,
+    cycles: &'a u64,
+}
+
+impl<'it, MO, T> Iterator for CycleIndexIter<'it, MO, T>
+where
+    MO: MapObserver<Entry = T> + for<'b> AsIter<'b, Item = T>,
+    T: Bounded + PartialEq + Default + Copy + Debug + 'static,
+{
+    type Item = &'it u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.into_iter.next().map(|e| {
+            if *e == self.map_initial {
+                self.initial
+            } else {
+                self.cycles
+            }
+        })
+    }
+}
+
+impl<'it, MO, T> AsIter<'it> for CyclesMapProxy<MO>
+where
+    MO: MapObserver<Entry = T> + for<'a> AsIter<'a, Item = T>,
+    T: Bounded + PartialEq + Default + Copy + Debug + 'static,
+{
+    type Item = u64;
+    type IntoIter = CycleIndexIter<'it, MO, T>;
+
+    fn as_iter(&'it self) -> Self::IntoIter {
+        CycleIndexIter {
+            map_initial: unsafe { self.map.as_ref().unwrap_unchecked().initial() },
+            into_iter: unsafe { self.map.as_ref().unwrap_unchecked().as_iter() },
+            initial: &self.initial,
+            cycles: &self.cycles,
+        }
+    }
+}
+
+impl<MO, T> MapObserver for CyclesMapProxy<MO>
+where
+    MO: MapObserver<Entry = T> + for<'a> AsIter<'a, Item = T>,
+    T: Bounded + PartialEq + Default + Copy + Debug + 'static,
+{
+    type Entry = u64;
+
+    fn get(&self, idx: usize) -> &Self::Entry {
+        if unsafe {
+            *self.map.as_ref().unwrap_unchecked().get(idx)
+                != self.map.as_ref().unwrap_unchecked().initial()
+        } {
+            &self.cycles
+        } else {
+            &self.initial
+        }
+    }
+
+    fn get_mut(&mut self, _idx: usize) -> &mut Self::Entry {
+        unimplemented!("Cannot implement get_mut for CyclesMapProxy.");
+    }
+
+    fn usable_count(&self) -> usize {
+        unsafe { self.map.as_ref().unwrap_unchecked().usable_count() }
+    }
+
+    fn count_bytes(&self) -> u64 {
+        unsafe { self.map.as_ref().unwrap_unchecked().count_bytes() }
+    }
+
+    fn hash(&self) -> u64 {
+        unimplemented!("No reason to implement hash for CyclesMapProxy.");
+    }
+
+    fn initial(&self) -> Self::Entry {
+        self.initial
+    }
+
+    fn reset_map(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn to_vec(&self) -> Vec<Self::Entry> {
+        (0..self.usable_count()).map(|idx| *self.get(idx)).collect()
+    }
+
+    fn how_many_set(&self, indexes: &[usize]) -> usize {
+        unsafe { self.map.as_ref().unwrap_unchecked().how_many_set(indexes) }
+    }
+}
+
+impl<F, CO, MO, S> Feedback<S> for CyclesMapFeedback<F, CO, MO>
+where
+    F: Feedback<S>,
+    CO: CyclesExecutedObserver + Debug,
+    MO: MapObserver,
+    S: UsesInput + HasClientPerfMonitor,
+{
+    fn init_state(&mut self, state: &mut S) -> Result<(), Error> {
+        self.inner.init_state(state)
+    }
+
+    fn is_interesting<EM, OT>(
+        &mut self,
+        state: &mut S,
+        manager: &mut EM,
+        input: &S::Input,
+        observers: &OT,
+        exit_kind: &ExitKind,
+    ) -> Result<bool, Error>
+    where
+        EM: EventFirer<State = S>,
+        OT: ObserversTuple<S>,
+    {
+        let cycles = observers.match_name::<CO>(&self.cycles_obs_name).unwrap();
+        let map = observers.match_name::<MO>(&self.map_obs_name).unwrap();
+        let proxy = CyclesMapProxy::new(
+            self.proxy_name.take().unwrap(),
+            cycles,
+            map,
+            self.cycles_initial,
+        );
+        let proxy_tuple = (proxy, ());
+        let interesting =
+            self.inner
+                .is_interesting(state, manager, input, &proxy_tuple, exit_kind)?;
+        let _ = self.proxy_name.insert(proxy_tuple.0.take_name());
+        Ok(interesting)
+    }
+
+    fn append_metadata(
+        &mut self,
+        state: &mut S,
+        testcase: &mut Testcase<S::Input>,
+    ) -> Result<(), Error> {
+        self.inner.append_metadata(state, testcase)
+    }
+
+    fn discard_metadata(&mut self, state: &mut S, input: &S::Input) -> Result<(), Error> {
+        self.inner.discard_metadata(state, input)
+    }
+}

--- a/libafl_verdi/Cargo.toml
+++ b/libafl_verdi/Cargo.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "libverdi"
+name = "libafl_verdi"
 version = "0.0.1"
 authors = ["Nassim Corteggiani <nassim.corteggiani@intel.com>"]
 edition = "2021"

--- a/libafl_verdi/src/npi_c.c
+++ b/libafl_verdi/src/npi_c.c
@@ -35,7 +35,6 @@ extern "C" {
 
   typedef struct {
     uint32_t* map;
-    unsigned char write_bit_index;
     unsigned write_byte_index;
     unsigned type;
     unsigned size;
@@ -117,6 +116,9 @@ extern "C" {
     while ( (block = npi_cov_iter_next( iter )) )
     {
       int covered =  npi_cov_get( npiCovCovered, block, test );
+      if(covered < 0)
+        covered = 0;
+
       cov_map->coverable = cov_map->coverable + npi_cov_get( npiCovCoverable, block, NULL );
       cov_map->covered = cov_map->covered + covered;
 
@@ -146,9 +148,8 @@ extern "C" {
     return;
 #else
     CoverageMap cov_map;
-    cov_map.map = &map[1];
-    cov_map.write_bit_index = 0;
-    cov_map.write_byte_index = 0;
+    cov_map.map = map;
+    cov_map.write_byte_index = 1;
     cov_map.type = coverage_type;
     cov_map.size = map_size;
     cov_map.coverable = 0;
@@ -180,7 +181,16 @@ extern "C" {
     npi_end();
 
     // assumption: float is 4bytes length, fits in u32
-    map[0] = (uint32_t)(((float)cov_map.covered / (float)cov_map.coverable) * 100.0);
+    float score = 0.0;
+    if(cov_map.coverable != 0) {
+      score = (((float)cov_map.covered / (float)cov_map.coverable) * 100.0);
+    }
+    printf("score is %f\n", score);
+    printf("coverable is %d\n", cov_map.coverable);
+    printf("covered is %d\n", cov_map.covered);
+
+    map[0] = (uint32_t)score;
+
 #endif
   }
 

--- a/libafl_verdi/src/npi_c.c
+++ b/libafl_verdi/src/npi_c.c
@@ -47,7 +47,7 @@ extern "C" {
   npiCovHandle vdb_cov_init(const char* vdb_file_path);
   void vdb_cov_end(npiCovHandle db);
   void compute_score( npiCovHandle inst, npiCovHandle test, CoverageMap* cov_map);
-  float update_cov_map(npiCovHandle db, uint32_t* map, unsigned map_size, unsigned coverage_type);
+  void update_cov_map(npiCovHandle db, uint32_t* map, unsigned map_size, unsigned coverage_type);
   void npi_init();
   
   void npi_init() {
@@ -126,7 +126,7 @@ extern "C" {
 #endif
   }
 
-  float update_cov_map(npiCovHandle db, uint32_t* map, unsigned map_size, unsigned coverage_type) {
+  void update_cov_map(npiCovHandle db, uint32_t* map, unsigned map_size, unsigned coverage_type) {
 #ifdef DUMMY_LIB
     std::srand(std::time(nullptr));
 
@@ -143,10 +143,10 @@ extern "C" {
        }
     }
 
-    return 0.0;
+    return;
 #else
     CoverageMap cov_map;
-    cov_map.map = map;
+    cov_map.map = &map[1];
     cov_map.write_bit_index = 0;
     cov_map.write_byte_index = 0;
     cov_map.type = coverage_type;
@@ -167,7 +167,7 @@ extern "C" {
         merged_test = npi_cov_merge_test( merged_test, test );
         if ( merged_test == NULL )
         {
-          return 1;
+          return;
         }
       }
     }
@@ -179,7 +179,8 @@ extern "C" {
     npi_cov_close( db );
     npi_end();
 
-    return ((float)cov_map.covered / (float)cov_map.coverable) * 100.0;
+    // assumption: float is 4bytes length, fits in u32
+    map[0] = (uint32_t)(((float)cov_map.covered / (float)cov_map.coverable) * 100.0);
 #endif
   }
 

--- a/libafl_verdi/src/npi_c.c
+++ b/libafl_verdi/src/npi_c.c
@@ -48,10 +48,11 @@ extern "C" {
   void vdb_cov_end(npiCovHandle db);
   void compute_score( npiCovHandle inst, npiCovHandle test, CoverageMap* cov_map);
   float update_cov_map(npiCovHandle db, uint32_t* map, unsigned map_size, unsigned coverage_type);
-
-  npiCovHandle vdb_cov_init(const char* vdb_file_path) {
+  void npi_init();
+  
+  void npi_init() {
 #ifdef DUMMY_LIB
-    return 0;
+    return;
 #else
     int argcv = 1;
     int& argc = argcv;
@@ -65,7 +66,13 @@ extern "C" {
     char**& argv = p_args;
 
     npi_init(argc, argv);
+#endif
+  }
 
+  npiCovHandle vdb_cov_init(const char* vdb_file_path) {
+#ifdef DUMMY_LIB
+    return 0;
+#else
     npiCovHandle db = npi_cov_open( vdb_file_path );
 
     return db;
@@ -184,13 +191,15 @@ extern "C" {
 #ifdef C_APP
 int main(int argc, char** argv) {
 
+  npi_init();
+
   void* db = vdb_cov_init(argv[1]);
 
   unsigned size = 41678;
   // unsigned size = 41678;
   uint32_t map[size] = {0};
 
-  update_cov_map(db, (uint32_t*) &map, size, 5);
+  update_cov_map(db, &map, size, 5);
 
   printf("[");
   unsigned i;

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -84,7 +84,7 @@ where
             let mut covered = 0; 
 
             let o_map = observer.my_map().as_slice();
-            for (i, item) in o_map.iter().enumerate().take(capacity) {
+            for (i, item) in o_map.iter().enumerate().filter(|&(i,_)| i>=2).take(capacity) {
                 if self.history[i] < *item {
                     self.history[i] = *item;
                     covered += *item;

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -72,6 +72,12 @@ where
         if self.score < observer.score() {
             self.score = observer.score();
 
+            for (i, item) in o_map.iter().enumerate().take(capacity) {
+                if self.history[i] < *item {
+                    self.history[i] = *item;
+                }
+            }
+
             // Save scrore into state
             manager.fire(
                 state,

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -86,49 +86,6 @@ where
 
         if interesting {
 
-            // self.history = observer.map().clone().to_vec();
-//
-            // let args = "-dir ./Coverage.vdb -full64 -format text -metric tgl -report ./urg_report";
-            // let mut command = pcmd::new("urg");
-            // let command = command.args(args.split(' '))
-                // .stdin(Stdio::piped())
-                // .stdout(Stdio::piped())
-                // .stderr(Stdio::piped());
-//
-            // let child = command.spawn().expect("failed to start process");
-//
-            // let output = command.output().expect("failed to start process");
-            // println!("status: {}", String::from_utf8_lossy(&output.stdout));
-            // println!("status: {}", String::from_utf8_lossy(&output.stderr));
-//
-            // let file = File::open("./urg_report/tests.txt").unwrap();
-//
-            // let reader = std::io::BufReader::new(file);
-//
-            // let lines: Vec<String> = reader
-                // .lines()
-                // .map(|line| line.expect("Something went wrong while parsing urg report"))
-                // .collect();
-//
-            // let lines = lines[4].split_whitespace();
-//
-            // let str_items: Vec<&str> = lines
-            // .map(|s| s)
-            // .collect();
-//
-            // println!("Coverage: {} \n", str_items[0]);
-//
-            // let score = str_items[0].parse::<f64>().unwrap();
-//
-            // manager.fire(
-                // state,
-                // Event::UpdateUserStats {
-                    // name: format!("coverage"),
-                    // value: UserStats::Float(score),
-                    // phantom: Default::default(),
-                // },
-            // )?;
-
             self.id += 1;
         }
         Ok(interesting)

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -92,6 +92,7 @@ where
                     covered += self.history[i];
                 }
             }
+            self.history[0] = covered;
         
             self.score = (covered as f32 / uncovered as f32) * 100.0;
  

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -117,25 +117,25 @@ where
                 .unwrap()
                 .success());
 
-            // Clean existing vdb
-            assert!(Command::new("rm")
-                .arg("-rf")
-                .arg("./Coverage.vdb")
-                .status()
-                .unwrap()
-                .success());
-
-            // Copy virgin vdb
-            assert!(Command::new("cp")
-                .arg("-r")
-                .arg("./Virgin_coverage.vdb")
-                .arg("./Coverage.vdb")
-                .status()
-                .unwrap()
-                .success());
-
             self.id += 1;
         }
+
+        // Clean existing vdb
+        assert!(Command::new("rm")
+            .arg("-rf")
+            .arg("./Coverage.vdb")
+            .status()
+            .unwrap()
+            .success());
+
+        // Copy virgin vdb
+        assert!(Command::new("cp")
+            .arg("-r")
+            .arg("./Virgin_coverage.vdb")
+            .arg("./Coverage.vdb")
+            .status()
+            .unwrap()
+            .success());
 
         Ok(interesting)
     }

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -106,27 +106,30 @@ where
             backup_path.push_str(&format!("/backup_{}", self.id));
 
             // backup the vdb folder
-            Command::new("cp")
-                .arg("-R")
+            let mut child = Command::new("cp")
+                .arg("-r")
                 .arg("./Coverage.vdb")
                 .arg(backup_path)
                 .spawn()
                 .expect("Verdi feedback failed to backup Coverage.vdb");
+            let _result = child.wait().unwrap();
 
             // Clean existing vdb
-            Command::new("rm")
+            let mut child = Command::new("rm")
                 .arg("-rf")
                 .arg("./Coverage.vdb")
                 .spawn()
                 .expect("Verdi feedback failed to remove vdb folder during cleaning phase");
+            let _result = child.wait().unwrap();
 
             // Copy virgin vdb
-            Command::new("cp")
+            let mut child = Command::new("cp")
                 .arg("-r")
                 .arg("./Virgin_coverage.vdb")
                 .arg("./Coverage.vdb")
                 .spawn()
                 .expect("Verdi feedback failed to copy virgin root vdb (expect Virgin_coverage.vdb)");
+            let _result = child.wait().unwrap();
 
             self.id += 1;
         }

--- a/libafl_verdi/src/verdi_feedback.rs
+++ b/libafl_verdi/src/verdi_feedback.rs
@@ -23,6 +23,7 @@ use libafl::monitors::UserStats;
 use libafl::events::{Event};
 use crate::verdi_observer::VerdiShMapObserver as VerdiObserver;
 use std::process::Command;
+use std::path::Path;
 
 extern crate fs_extra;
 
@@ -108,6 +109,15 @@ where
 
             let mut backup_path = self.workdir.clone();
             backup_path.push_str(&format!("/backup_{}", self.id));
+            
+            manager.fire(
+                state,
+                Event::UpdateUserStats {
+                    name: "VDB".to_string(),
+                    value: UserStats::String( backup_path.clone()),
+                    phantom: Default::default(),
+                },
+            )?;
 
             // backup the vdb folder
             assert!(Command::new("cp")

--- a/libafl_verdi/src/verdi_observer.rs
+++ b/libafl_verdi/src/verdi_observer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libafl::{
-    bolts::{tuples::Named, AsIter, HasLen},
+    bolts::{tuples::Named, AsIter, HasLen, AsMutSlice, AsSlice},
     executors::{ExitKind},
     observers::{MapObserver, Observer},
     observers::{DifferentialObserver, ObserversTuple},
@@ -15,10 +15,13 @@ use core::{
     slice::from_raw_parts,
     fmt::Debug,
     slice::IterMut,
+    slice::Iter,
 };
 use libafl::prelude::AsIterMut;
 use serde::{Deserialize, Serialize};
 use libc::{c_uint, c_char, c_void, c_float};
+use nix::{sys::wait::waitpid,unistd::{fork, ForkResult}};
+use libafl::prelude::OwnedMutSlice;
 
 extern crate fs_extra;
 use std::{
@@ -26,6 +29,7 @@ use std::{
     hash::Hasher,
     ffi::{CString},
 };
+use std::process;
 use ahash::AHasher;
 use num_traits::Bounded;
 type NpiCovHandle = *mut c_void;
@@ -33,11 +37,13 @@ type NpiCovHandle = *mut c_void;
 #[link(name = "npi_c", kind = "static")]
 extern "C" {
 
-      fn vdb_cov_init(vdb_file_path: *const c_char) -> NpiCovHandle;
+    fn vdb_cov_init(vdb_file_path: *const c_char) -> NpiCovHandle;
 
-      fn vdb_cov_end(db: NpiCovHandle) -> c_void;
+    fn vdb_cov_end(db: NpiCovHandle) -> c_void;
 
-      fn update_cov_map(db: NpiCovHandle, map: *mut c_char, map_size: c_uint, coverage_type: c_uint) -> c_float;
+    fn update_cov_map(db: NpiCovHandle, map: *mut c_uint, map_size: c_uint, coverage_type: c_uint) -> c_float;
+
+    fn npi_init() -> c_void;
 }
 
 /// A simple observer, just overlooking the runtime of the target.
@@ -49,7 +55,7 @@ where
     name: String,
     initial: T,
     cnt: usize,
-    map: Vec<T>,
+    map: Vec<T>, 
     workdir: String,
     metric: u32,
     score: f32
@@ -65,10 +71,12 @@ impl<T> VerdiMapObserver<T>
 where
     T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
 {
+
     /// Creates a new [`VerdiMapObserver`] with the given name.
     #[must_use]
     pub fn new(name: &'static str, workdir: &String, size: usize, metric: &VerdiCoverageMetric) -> Self {
 
+        unsafe { npi_init();}
         Self {
             name: name.to_string(),
             initial: T::default(),
@@ -190,7 +198,7 @@ where
 
     fn how_many_set(&self, indexes: &[usize]) -> usize {
         indexes
-            .into_iter()
+            .iter()
             .map(|&idx| self.get(idx))
             .filter(|&&e| e != self.initial())
             .count()
@@ -215,20 +223,19 @@ where
         _exit_kind: &ExitKind,
     ) -> Result<(), Error> {
 
-        unsafe {
-            let pmap = self.map.as_mut_ptr();
-            self.map.set_len(self.cnt);
+            unsafe {
+                let pmap = self.map.as_mut_ptr();
+                self.map.set_len(self.cnt);
 
-            let vdb = CString::new("./Coverage.vdb").expect("CString::new failed");
-            let db = vdb_cov_init(vdb.as_ptr());
+                let vdb = CString::new("./Coverage.vdb").expect("CString::new failed");
+                let db = vdb_cov_init(vdb.as_ptr());
 
-            self.score = update_cov_map(db, pmap as *mut c_char, self.cnt as c_uint, 5);
+                self.score = update_cov_map(db, pmap as *mut c_uint, self.cnt as c_uint, self.metric as c_uint);
 
-            vdb_cov_end(db);
+                vdb_cov_end(db);
+            }
+            Ok(())
         }
-
-        Ok(())
-    }
 }
 
 impl<'it, T> AsIter<'it> for VerdiMapObserver<T>
@@ -278,5 +285,314 @@ where
         Ok(())
     }
 }
+
+
+/// A simple observer, just overlooking the runtime of the target.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(bound = "T: serde::de::DeserializeOwned")]
+#[allow(clippy::unsafe_derive_deserialize)]
+pub struct VerdiShMapObserver<'a, T, const N: usize> 
+where
+    T: Default + Copy + 'static + Serialize,
+{
+    name: String,
+    initial: T,
+    cnt: usize,
+    map: OwnedMutSlice<'a, T>,
+    workdir: String,
+    metric: u32,
+    score: f32
+}
+
+impl<'a, T, const N: usize> VerdiShMapObserver<'a, T, N>
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug,
+{
+    /// Creates a new [`MapObserver`]
+    ///
+    /// # Note
+    /// Will get a pointer to the map and dereference it at any point in time.
+    /// The map must not move in memory!
+    #[must_use]
+    pub fn new(name: &'static str, workdir: &String, map: &'a mut [T], metric: &VerdiCoverageMetric) -> Self {
+        assert!(map.len() >= N);
+        unsafe {
+            npi_init();
+        }
+        Self {
+            name: name.to_string(),
+            initial: T::default(),
+            cnt: map.len(),
+            map: OwnedMutSlice::from(map),
+            workdir: workdir.to_string(),
+            metric: *metric as u32,
+            score: 0.0
+        }
+    }
+
+    /// Creates a new [`VerdiMapObserver`] from a raw pointer
+    ///
+    /// # Safety
+    /// Will dereference the `map_ptr` with up to len elements.
+    #[must_use]
+    pub unsafe fn from_mut_ptr(name: &'static str, workdir: &String, map_ptr: *mut T, metric: &VerdiCoverageMetric) -> Self
+    {
+        npi_init();
+
+        Self {
+            name: name.to_string(),
+            initial: T::default(),
+            cnt: N,
+            map: OwnedMutSlice::from_raw_parts_mut(map_ptr, N),
+            workdir: workdir.to_string(),
+            metric: *metric as u32,
+            score: 0.0
+        }
+    }
+
+    /// Gets cnt as usize
+    #[must_use]
+    pub fn cnt(&self) -> usize {
+        self.cnt
+    }
+    
+    /// Gets map ptr
+    #[must_use]
+    pub fn my_map(&self) -> &[T] {
+        self.map.as_slice()
+    }
+    
+    /// Gets score as f32
+    #[must_use]
+    pub fn score(&self) -> f32 {
+        self.score
+    }
+
+}
+
+impl<'a, T, const N: usize> Named for VerdiShMapObserver<'a, T, N>
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl<'a, T, const N:usize> HasLen for VerdiShMapObserver<'a, T, N>
+where
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned,
+{
+
+    fn len(&self) -> usize {
+        N
+    }
+}
+
+impl<'a, T, const N: usize> MapObserver for VerdiShMapObserver<'a, T, N>
+where
+    // T: Default + Copy + 'static + Serialize + Bounded + PartialEq + Debug + Serialize + serde::de::DeserializeOwned
+    T: Bounded
+        + PartialEq
+        + Default
+        + Copy
+        + 'static
+        + Serialize
+        + serde::de::DeserializeOwned
+        + Debug
+{
+    type Entry = T;
+
+    #[inline]
+    fn initial(&self) -> T {
+        self.initial
+    }
+
+    #[inline]
+    fn get(&self, idx: usize) -> &T {
+        &self.map.as_slice()[idx]
+    }
+
+    #[inline]
+    fn get_mut(&mut self, idx: usize) -> &mut T {
+        &mut self.map.as_mut_slice()[idx]
+    }
+
+    /// Count the set bytes in the map
+    fn count_bytes(&self) -> u64 {
+        let initial = self.initial();
+        let cnt = self.usable_count();
+        let map = self.map.as_slice();
+        let mut res = 0;
+        for x in map[0..cnt].iter() {
+            if *x != initial {
+                res += 1;
+            }
+        }
+        res
+    }
+
+    fn usable_count(&self) -> usize {
+        self.map.as_slice().len()
+    }
+
+    fn hash(&self) -> u64 {
+
+        let slice = &self.map.as_slice();
+
+        let mut hasher = AHasher::new_with_keys(0, 0);
+        let ptr = slice.as_ptr() as *const u8;
+        let map_size = slice.len() / core::mem::size_of::<u32>();
+        unsafe {
+            hasher.write(from_raw_parts(ptr, map_size));
+        }
+        hasher.finish()
+    }
+
+    /// Reset the map
+    #[inline]
+    fn reset_map(&mut self) -> Result<(), Error> {
+        // Normal memset, see https://rust.godbolt.org/z/Trs5hv
+        let initial = self.initial();
+        let cnt = self.usable_count();
+        let map = self.map.as_mut_slice();
+        for x in map[0..cnt].iter_mut() {
+            *x = initial;
+        }
+        Ok(())
+    }
+
+    fn to_vec(&self) -> Vec<T> {
+        self.map.as_slice().to_vec()
+    }
+
+    /// Get the number of set entries with the specified indexes
+    fn how_many_set(&self, indexes: &[usize]) -> usize {
+        let initial = self.initial();
+        let cnt = self.usable_count();
+        let map = self.map.as_slice();
+        let mut res = 0;
+        for i in indexes {
+            if *i < cnt && map[*i] != initial {
+                res += 1;
+            }
+        }
+        res
+    }
+}
+
+impl<'a, S, T, const N: usize> Observer<S> for VerdiShMapObserver<'a, T, N> 
+where
+    S: UsesInput,
+    T: Bounded + Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug + PartialEq
+{
+    fn pre_exec(&mut self, _state: &mut S, _input: &S::Input) -> Result<(), Error> {
+        let map = self.map.as_mut_slice();
+        for x in map[0..N].iter_mut() {
+            *x = self.initial;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn post_exec(
+       &mut self,
+        _state: &mut S,
+        _input: &S::Input,
+        _exit_kind: &ExitKind,
+    ) -> Result<(), Error> {
+
+        let pmap = self.map.as_slice();
+
+        let pmap = pmap.as_ptr();
+
+        let vdb = CString::new("./Coverage.vdb").expect("CString::new failed");
+
+        match unsafe{fork()} {
+            Ok(ForkResult::Parent{child, ..}) => {
+                waitpid(child, None).unwrap();
+            }
+            Ok(ForkResult::Child) => {
+                unsafe {
+                    let db = vdb_cov_init(vdb.as_ptr());
+                    
+                    self.score = update_cov_map(db, pmap as *mut c_uint, N as c_uint, self.metric as c_uint);
+
+                    vdb_cov_end(db);
+
+                    process::exit(0);
+                }
+            },
+            Err(_) => println!("libafl_verdi failed to fork to invoke libNPI.so ..."),
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, 'it, T, const N: usize> AsIter<'it> for VerdiShMapObserver<'a, T, N>
+where
+    T: Bounded
+        + PartialEq
+        + Default
+        + Copy
+        + 'static
+        + Serialize
+        + serde::de::DeserializeOwned
+        + Debug,
+{
+    type Item = T;
+    type IntoIter = Iter<'it, T>;
+
+    fn as_iter(&'it self) -> Self::IntoIter {
+        let cnt = self.usable_count();
+        self.map.as_slice()[..cnt].iter()
+    }
+}
+
+impl<'a, 'it, T, const N: usize> AsIterMut<'it> for VerdiShMapObserver<'a, T, N>
+where
+    T: Bounded
+        + PartialEq
+        + Default
+        + Copy
+        + 'static
+        + Serialize
+        + serde::de::DeserializeOwned
+        + Debug
+{
+    type Item = T;
+    type IntoIter = IterMut<'it, T>;
+
+    fn as_iter_mut(&'it mut self) -> Self::IntoIter {
+        let cnt = self.usable_count();
+        self.map.as_mut_slice()[..cnt].iter_mut()
+    }
+}
+
+impl<'a, OTA, OTB, S, T, const N: usize> DifferentialObserver<OTA, OTB, S> for VerdiShMapObserver<'a, T, N>
+where
+    OTA: ObserversTuple<S>,
+    OTB: ObserversTuple<S>,
+    S: UsesInput,
+    T: Default + Copy + 'static + Serialize + serde::de::DeserializeOwned + Debug + PartialEq  + num_traits::Bounded,
+{
+    fn pre_observe_first(&mut self, _observers: &mut OTA) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn post_observe_first(&mut self, _observers: &mut OTA) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn pre_observe_second(&mut self, _observers: &mut OTB) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn post_observe_second(&mut self, _observers: &mut OTB) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
 
 

--- a/libafl_verdi/src/verdi_observer.rs
+++ b/libafl_verdi/src/verdi_observer.rs
@@ -60,8 +60,8 @@ pub struct VerdiMapObserver
 
 #[derive(Copy, Clone)]
 pub enum VerdiCoverageMetric {
-    Toggle = 4,
-    Line = 5
+    Toggle = 5,
+    Line = 4
 }
 
 impl VerdiMapObserver

--- a/libafl_verdi/src/verdi_observer.rs
+++ b/libafl_verdi/src/verdi_observer.rs
@@ -71,7 +71,7 @@ impl VerdiMapObserver
     #[must_use]
     pub fn new(name: &'static str, workdir: &String, size: usize, metric: &VerdiCoverageMetric) -> Self {
 
-        unsafe { npi_init();}
+        // unsafe { npi_init();}
         Self {
             name: name.to_string(),
             initial: u32::default(),
@@ -200,6 +200,8 @@ where
                 let pmap = self.map.as_mut_ptr();
                 self.map.set_len(self.cnt);
 
+                npi_init();
+
                 let vdb = CString::new("./Coverage.vdb").expect("CString::new failed");
                 let db = vdb_cov_init(vdb.as_ptr());
 
@@ -278,9 +280,9 @@ impl<'a, const N: usize> VerdiShMapObserver<'a, N>
     #[must_use]
     pub fn new(name: &'static str, workdir: &String, map: &'a mut [u32], metric: &VerdiCoverageMetric) -> Self {
         assert!(map.len() >= N);
-        unsafe {
-            npi_init();
-        }
+        // unsafe {
+            // npi_init();
+        // }
         Self {
             name: name.to_string(),
             initial: u32::default(),
@@ -298,7 +300,7 @@ impl<'a, const N: usize> VerdiShMapObserver<'a, N>
     #[must_use]
     pub unsafe fn from_mut_ptr(name: &'static str, workdir: &String, map_ptr: *mut u32, metric: &VerdiCoverageMetric) -> Self
     {
-        npi_init();
+        // npi_init();
 
         Self {
             name: name.to_string(),
@@ -453,6 +455,9 @@ where
             }
             Ok(ForkResult::Child) => {
                 unsafe {
+
+                    npi_init();
+
                     let db = vdb_cov_init(vdb.as_ptr());
                     
                     update_cov_map(db, pmap as *mut c_uint, N as c_uint, self.metric as c_uint);

--- a/libafl_verilator/build.rs
+++ b/libafl_verilator/build.rs
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::Path;
-use std::env;
-
 fn main() {
 }
 


### PR DESCRIPTION
We often want to use testcases which minimise the amount of cycles for a given coverage point, for the purposes of reducing execution time. This PR adds the CyclesMapFeedback, which offers a cycle minimiser (or maximiser!) that can be used in place of a typical map feedback.

Note that this is untested as of yet because I do not have a way to count cycles currently :)